### PR TITLE
Add optional parameter to #contains() and #by() to toggle if the end value should be inclusive or exclusive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ range.contains(lol); // true
 range.contains(wat); // false
 ```
 A optional second parameter indicates if the end of the range
-should be excluded when testing for contains
+should be excluded when testing for inclusion
 ``` javascript
 range.contains(end) // true
 range.contains(end, false) // true
@@ -119,10 +119,10 @@ acc.length == 5 // true
 ```
 
 Iteration also supports excluding the end value of the range by setting the
-last parameter to true.
+last parameter to ```true```.
 ``` javascript
 acc2 = [];
-range.by('d', function (moment) {
+range1.by('d', function (moment) {
   acc2.push(moment)
 }, true);
 acc2.length == 4 // true

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ var range2 = moment().range(lol, wat);
 range.contains(lol); // true
 range.contains(wat); // false
 ```
+A optional second parameter indicates if the end of the range
+should be excluded when testing for contains
+``` javascript
+range.contains(end) // true
+range.contains(end, false) // true
+range.contains(end, true) // false
+```
+
 
 Find out if your moment falls within a date range:
 
@@ -108,6 +116,17 @@ range1.by(range2, function(moment) {
 });
 
 acc.length == 5 // true
+```
+
+Iteration also supports excluding the end value of the range by setting the
+last parameter to true.
+``` javascript
+acc2 = [];
+range.by('d', function (moment) {
+  acc2.push(moment)
+}, true);
+acc2.length == 4 // true
+
 ```
 
 ### Compare

--- a/src/moment-range.coffee
+++ b/src/moment-range.coffee
@@ -35,14 +35,15 @@ class DateRange
     * Determine if the current interval contains a given moment/date/range.
     *
     * @param {(Moment|Date|DateRange)} other Date to check
+    * @param {!boolean} exclusive True if the to value is exclusive
     *
     * @return {!boolean}
   *###
-  contains: (other) ->
+  contains: (other, exclusive) ->
     if other instanceof DateRange
-      @start <= other.start and @end >= other.end
+      @start <= other.start and (@end > other.end or (@end.isSame(other.end) and not exclusive))
     else
-      @start <= other <= @end
+      @start <= other and (@end > other or (@end.isSame(other) and not exclusive))
 
   ###*
     * @private

--- a/src/moment-range.coffee
+++ b/src/moment-range.coffee
@@ -48,18 +48,22 @@ class DateRange
   ###*
     * @private
   *###
-  _by_string: (interval, hollaback) ->
+  _by_string: (interval, hollaback, exclusive) ->
     current = moment(@start)
-    while @contains(current)
+    while @contains(current, exclusive)
       hollaback.call(@, current.clone())
       current.add(1, interval)
 
   ###*
     * @private
   *###
-  _by_range: (range_interval, hollaback) ->
-    l = Math.floor(@ / range_interval)
+  _by_range: (range_interval, hollaback, exclusive) ->
+    div = @ / range_interval
+    l = Math.floor(div)
     return @ if l is Infinity
+    if (l == div and exclusive)
+      l = l - 1
+
 
     for i in [0..l]
       hollaback.call(@, moment(@start.valueOf() + range_interval.valueOf() * i))
@@ -135,14 +139,16 @@ class DateRange
     *                                        or shorthand string (shorthands:
     *                                        http://momentjs.com/docs/#/manipulating/add/)
     * @param {!function(Moment)}   hollaback Function to execute for each sub-range
+    * @param {!boolean}            exclusive Indicate that the end of the range
+    *                                        should not be included in the iter.
     *
     * @return {!boolean}
   *###
-  by: (range, hollaback) ->
+  by: (range, hollaback, exclusive) ->
     if typeof range is 'string'
-      @_by_string(range, hollaback)
+      @_by_string(range, hollaback, exclusive)
     else
-      @_by_range(range, hollaback)
+      @_by_range(range, hollaback, exclusive)
     @ # Chainability
 
   ###*

--- a/test/moment-range.coffee
+++ b/test/moment-range.coffee
@@ -185,6 +185,19 @@ describe 'DateRange', ->
       dr1.by dr2, ((d) -> acc.push d.utc().format('YYYY-MM-DD')), true
       acc.should.eql ['2014-04-02', '2014-04-03']
 
+    it 'should be exlusive when using by with minutes as well', ->
+      d1 = moment('2014-01-01T00:00:00.000Z')
+      d2 = moment('2014-01-01T00:06:00.000Z')
+      dr = moment.range(d1, d2)
+
+      acc = []
+      dr.by 'm', ((d) -> acc.push d.utc().format('mm'))
+      acc.should.eql ['00', '01', '02', '03', '04', '05', '06']
+
+      acc = []
+      dr.by 'm', ((d) -> acc.push d.utc().format('mm')), true
+      acc.should.eql ['00', '01', '02', '03', '04', '05']
+
   describe '#contains()', ->
     it 'should work with Date objects', ->
       dr = moment.range(d_1, d_2)

--- a/test/moment-range.coffee
+++ b/test/moment-range.coffee
@@ -176,11 +176,11 @@ describe 'DateRange', ->
     it 'should be exlusive when the exclusive param is set', ->
       dr1 = moment.range(m_1, m_2)
       dr1.contains(dr1, true).should.be.false
-      # dr1.contains(dr1, false).should.be.true
-      # dr1.contains(dr1).should.be.true
+      dr1.contains(dr1, false).should.be.true
+      dr1.contains(dr1).should.be.true
       dr1.contains(m_2, true).should.be.false
-      # dr1.contains(m_2, false).should.be.true
-      # dr1.contains(m_2).should.be.true
+      dr1.contains(m_2, false).should.be.true
+      dr1.contains(m_2).should.be.true
 
   describe '#overlaps()', ->
     it 'should work with DateRange objects', ->

--- a/test/moment-range.coffee
+++ b/test/moment-range.coffee
@@ -173,6 +173,15 @@ describe 'DateRange', ->
       dr1.contains(m_4).should.be.true
       dr1.contains(dr1).should.be.true
 
+    it 'should be exlusive when the exclusive param is set', ->
+      dr1 = moment.range(m_1, m_2)
+      dr1.contains(dr1, true).should.be.false
+      # dr1.contains(dr1, false).should.be.true
+      # dr1.contains(dr1).should.be.true
+      dr1.contains(m_2, true).should.be.false
+      # dr1.contains(m_2, false).should.be.true
+      # dr1.contains(m_2).should.be.true
+
   describe '#overlaps()', ->
     it 'should work with DateRange objects', ->
       dr_1 = moment.range(m_1, m_2)

--- a/test/moment-range.coffee
+++ b/test/moment-range.coffee
@@ -150,6 +150,41 @@ describe 'DateRange', ->
 
       acc.should.eql ['2012-01', '2012-02', '2012-03']
 
+    it 'should not include .end in the iteration if exclusive is set to true when iterating by string', ->
+      my1 = moment('2014-04-02T00:00:00.000Z')
+      my2 = moment('2014-04-04T00:00:00.000Z')
+      dr1 = moment.range(my1, my2)
+
+      acc = []
+      dr1.by 'd', ((d) -> acc.push d.utc().format('YYYY-MM-DD')), false
+      acc.should.eql ['2014-04-02', '2014-04-03', '2014-04-04']
+
+      acc = []
+      dr1.by 'd', ((d) -> acc.push d.utc().format('YYYY-MM-DD')), true
+      acc.should.eql ['2014-04-02', '2014-04-03']
+
+      acc = []
+      dr1.by 'd', ((d) -> acc.push d.utc().format('YYYY-MM-DD'))
+      acc.should.eql ['2014-04-02', '2014-04-03', '2014-04-04']
+
+    it 'should not include .end in the iteration if exclusive is set to true when iterating by range', ->
+      my1 = moment('2014-04-02T00:00:00.000Z')
+      my2 = moment('2014-04-04T00:00:00.000Z')
+      dr1 = moment.range(my1, my2)
+      dr2 = moment.range(my1, moment('2014-04-03T00:00:00.000Z'))
+
+      acc = []
+      dr1.by dr2, (d) -> acc.push d.utc().format('YYYY-MM-DD')
+      acc.should.eql ['2014-04-02', '2014-04-03', '2014-04-04']
+
+      acc = []
+      dr1.by dr2, ((d) -> acc.push d.utc().format('YYYY-MM-DD')), false
+      acc.should.eql ['2014-04-02', '2014-04-03', '2014-04-04']
+
+      acc = []
+      dr1.by dr2, ((d) -> acc.push d.utc().format('YYYY-MM-DD')), true
+      acc.should.eql ['2014-04-02', '2014-04-03']
+
   describe '#contains()', ->
     it 'should work with Date objects', ->
       dr = moment.range(d_1, d_2)


### PR DESCRIPTION
Sample usage
```javascript
>>> myRange = moment().range(dateA, dateB);
undefined
>>> myRange.contains(dateB);
true
>>> myRange.contains(dateB, true);
false
```
i.e. the second parameter toggles if the end value should be excluded in the comparison. 
It is also included in ```#by()```, where the parameter has the same meaning, but the usage results in the following
```javascript
>>> d1 = moment('2014-01-01T00:00:00.000Z')
...
>>> d2 = moment('2014-01-01T00:06:00.000Z')
...
>>> moment.range(d1, d2);
>>> dr.by('m', function(d) {console.log(d.utc().format('mm'))})
00
01
02
03
04
05
06
>>> acc
 ['00', '01', '02', '03', '04', '05', '06']
>>> dr.by('m', function(d) {console.log(d.utc().format('mm'))}, true)
00
01
02
03
04
05
```
Fixes #61 (and #60)
