### PR TITLE
Remove consts for backward-compatibility with IE10

### DIFF
--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -2,9 +2,9 @@
 // Contstants
 //-----------------------------------------------------------------------------
 
-const moment = require('moment');
+var moment = require('moment');
 
-const INTERVALS = {
+var INTERVALS = {
   year:   true,
   month:  true,
   week:   true,


### PR DESCRIPTION
IE10 has no notion of a const and will break with a syntax error if you try to use them. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const

Better to just use the `var ALLCAPS` convention