### PR TITLE
ES6 setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,12 @@ var moment = require('moment');
 require('moment-range');
 ```
 
+Or for `import` statements:
+``` javascript
+import moment from 'moment';
+import 'moment-range';
+```
+
 ### Browser
 
 Simply include moment-range after moment.js:


### PR DESCRIPTION
It took me a little while to figure out a graceful way of setting up this project on ES6.

Added a section below the `require` instructions for `import` instructions:

``` js
import moment from 'moment';
import 'moment-range';
```

This may go without saying for some people, but I think there will be a lot of people in the same camp as myself that tried to set up like a normal import:

``` js
import moment from 'moment';
import momentRange from 'moment-range';
```

And were left with an unused import variable, especially troublesome for linters and not quite the indented approach.
