### PR TITLE
Make toArray return moments at the start of the given range.

### DIFF
--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -193,7 +193,7 @@ DateRange.prototype.subtract = function(other) {
 DateRange.prototype.toArray = function(by, exclusive) {
   var acc = [];
   this.by(by, function(unit) {
-    acc.push(unit);
+    acc.push(unit.startOf(by));
   }, exclusive);
   return acc;
 };


### PR DESCRIPTION
If I generate a range of the last 3 months:

``` js
moment.range(moment().subtract(3 - 1, "months"), moment()).toArray("months").map(m => m.format())
```

I'd expect each moment in the resulting range to be the first day of the month:

``` js
["2016-05-01T00:00:00+02:00", "2016-06-01T00:00:00+02:00", "2016-07-01T00:00:00+02:00"]
```

Instead of the current behavior:

``` js
["2016-05-15T09:09:15+02:00", "2016-06-15T09:09:15+02:00", "2016-07-15T09:09:15+02:00"]
```
