### PR TITLE
Let "main" point to lib/

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "homepage": "https://github.com/gf3/moment-range",
   "bugs": "https://github.com/gf3/moment-range/issues",
-  "main": "./dist/moment-range",
+  "main": "./lib/moment-range",
   "directories": {
     "lib": "./lib"
   },


### PR DESCRIPTION
Hey guys.

You once changed the `main` prop of the `package.json` to point to the `dist/` file which is rather uncommon. As I pointed out in this issue this may lead to hard-to-track errors in some use cases: https://github.com/gf3/moment-range/issues/118

Was there any special reason for that?

Cheers
