### PR TITLE
start can only be in intervals if it is a string, otherwise the expen…

### DIFF
--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -337,7 +337,7 @@ DateRange.prototype.diff = function(unit) {
  * @return {!DateRange}
  */
 moment.range = function(start, end) {
-  if (start in INTERVALS) {
+  if (!start instanceof moment && start in INTERVALS) {
     return new DateRange(moment(this).startOf(start), moment(this).endOf(start));
   }
   else {


### PR DESCRIPTION
…sive toString() method will be called.

The solution could be to check whether the start argument is already of type moment, another solution could be to check if it is not string.
