### PR TITLE
removing the `module` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+* 'module' has been replaced with 'jsnext:main' to support both rollup and webpack 2
 
 ## [3.0.2]
 ### Changed

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/gf3/moment-range",
   "bugs": "https://github.com/gf3/moment-range/issues",
   "main": "./dist/moment-range",
-  "module": "lib/moment-range.js",
+  "jsnext:main": "lib/moment-range.js",
   "version": "3.0.2",
   "engines": {
     "node": "*"


### PR DESCRIPTION
removing the `module` directive and replacing it with the rollup `jsnext:main` directive. webpack and browserify do not read this directive.

associate with #155 #153 #149 